### PR TITLE
add ability to pass geocomplete options

### DIFF
--- a/lib/client/autoform-google-places-input.js
+++ b/lib/client/autoform-google-places-input.js
@@ -155,7 +155,7 @@ Template.afGooglePlaceInput.onRendered(function () {
  */
 Template.afGooglePlaceInput.events({
   'focusout .af-google-place-input': function () {
-    if( $('.input[name="' + this.name + '"').val() == '' ) {
+    if( $('input[name="' + this.name + '"]').val() == '' ) {
       Session.set('abdj-google-place-input-' + this.name, {});
     }
   }

--- a/lib/client/autoform-google-places-input.js
+++ b/lib/client/autoform-google-places-input.js
@@ -105,6 +105,7 @@ Template.afGooglePlaceInput.onCreated(function () {
 
 
 Template.afGooglePlaceInput.onRendered(function () {
+  var instance = this;
   var _name = this.data.name;
   var options = fieldOption[_name];
 
@@ -119,7 +120,14 @@ Template.afGooglePlaceInput.onRendered(function () {
         }
       }
 
-      _inputGeocomplete = _element.geocomplete();
+      // create component with options if they exist
+      if (_.has(instance.data, 'geocompleteOptions')) {
+        _inputGeocomplete = _element.geocomplete(instance.data.geocompleteOptions);
+      }
+      else {
+        _inputGeocomplete = _element.geocomplete();
+      }
+      
 
       _inputGeocomplete.bind("geocode:result", function(event, result) {
         setAddress(_name, result.formatted_address, result.geometry.location.lng(), result.geometry.location.lat(), result.address_components);


### PR DESCRIPTION
I needed the ability to restrict country so I threw this together... It should work with all geocomplete options but I'm not 100% sure of the reactivity. Thanks for putting together such a useful package that works.

I define the data in my schema like so...  
  "destination.address": {
    type: Schemas.Address,
    optional: true,
      autoform: {
        type: 'google-places-input',
        data: {'geocompleteOptions': {'componentRestrictions': {country: "AU"}} }
      }
  }
